### PR TITLE
Ignore errors from substitution commands.

### DIFF
--- a/plugin/rename.vim
+++ b/plugin/rename.vim
@@ -22,7 +22,7 @@ function! Rename(name, bang)
 	let l:curpath = expand("%:h") . "/"
 	let v:errmsg = ""
 	silent! exe "saveas" . a:bang . " " . fnameescape(l:curpath . a:name)
-	if v:errmsg =~# '^$\|^E329'
+	if v:errmsg =~# '^$\|^E329\|^E486'
 		let l:oldfile = l:curfile
 		let l:curfile = expand("%:p")
 		if l:curfile !=# l:oldfile && filewritable(l:curfile)


### PR DESCRIPTION
If you automatically trim spaces when you write a buffer via something like `%s/\s\+$//e` and there is nothing to trim, you get an _E486: Pattern not found: …_. This error should not disturb the script so it should be added to the ignore list.
